### PR TITLE
Use LaTeX for math formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ At the moment, the repo includes the `oner` library that learns single condition
 ***OneR***
 
 OneR algorithm generates one rule for each predictor in a dataset, then selects the rule with the smallest total error as its "one rule". 
-The `oner` implementation in this repo generates "one rule" for each predictor, by assessing the product of its coverage and accuracy `(coverage * (1-error))`
+The `oner` implementation in this repo generates "one rule" for each predictor, by assessing the product of its coverage and accuracy $(coverage \times (1-error))$
 and provides various options for the consuming application to select one rule.
 
 To create a rule for a predictor, a frequency table is constructed for each predictor against the target. 
-For `categorical` features the test conditions are `predictor=value_i` (for each discrete predictor value). For example:
+For `categorical` features the test conditions are $predictor=value_i$ (for each discrete predictor value). For example:
 
 ![This is an alt text.](FrequencyTable_Outlook.jpg "This is a sample image.")
 
@@ -24,7 +24,7 @@ For each condition the most frequent (majority) class is assigned to the rule:
 >> IF outlook=overcast THEN Yes [coverage=4/14, accuracy=1]
 >> IF outlook=rainy THEN No [coverage=5/15, accuracy=2/5]
 ```
-The different rules that can be generated from a single predictor are assessed based on their `coverage*accuracy` score:
+The different rules that can be generated from a single predictor are assessed based on their $coverage \times accuracy$ score:
 ```
 >> IF outlook=sunny THEN Yes [coverage=5/14, accuracy=3/5] [score=0.21]
 >> IF outlook=overcast THEN YES [coverage=4/14, accuracy=1] [score=0.28]
@@ -33,7 +33,7 @@ The different rules that can be generated from a single predictor are assessed b
 The rule with the highest score is selected as the `one rule` for the predictor.
 
 For `numerical` features splitting points are calculated and used to test conditions like 
-`predictor >= split_point_i AND predictor < split_point_j`.
+$predictor \geq splitPoint_i \land predictor < splitPoint_j$.
 
 ## Usage
 - Add `emla` module as a dependency to your project


### PR DESCRIPTION
FYI, GitHub supports LaTeX-formatted [math expressions](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions).

You can use the rich diff mode to see the result and decide whether you like this change or not:
![image](https://github.com/nprentza/emla/assets/673386/8d8599cc-2061-4d82-999f-6809e3ed9af5)
